### PR TITLE
Feature/#8 카카오 로그인 중 성별, 생일 바인딩하는 기능 추가

### DIFF
--- a/src/main/java/dnd/myOcean/config/oAuth/kakao/KakaoUserInfo.java
+++ b/src/main/java/dnd/myOcean/config/oAuth/kakao/KakaoUserInfo.java
@@ -7,7 +7,9 @@ import java.util.Map;
 public class KakaoUserInfo {
 
     public static final String KAKAO_ACCOUNT = "kakao_account";
+    private static final String PROFILE = "profile";
     public static final String EMAIL = "email";
+    private static final String NICKNAME = "nickname";
 
     private Map<String, Object> attributes;
 
@@ -24,5 +26,19 @@ public class KakaoUserInfo {
                 });
 
         return (String) account.get(EMAIL);
+    }
+
+    public String getName() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        Object kakaoAccount = attributes.get(KAKAO_ACCOUNT);
+
+        Map<String, Object> account = objectMapper.convertValue(kakaoAccount, new TypeReference<>() {
+        });
+
+        Object profile = account.get(PROFILE);
+        Map<String, Object> profileMap = objectMapper.convertValue(profile, new TypeReference<>() {
+        });
+
+        return (String) profileMap.get(NICKNAME);
     }
 }

--- a/src/main/java/dnd/myOcean/controller/oAuth/SignController.java
+++ b/src/main/java/dnd/myOcean/controller/oAuth/SignController.java
@@ -1,12 +1,15 @@
 package dnd.myOcean.controller.oAuth;
 
+import dnd.myOcean.domain.member.Member;
+import dnd.myOcean.dto.member.request.MemberBirthdayRequest;
+import dnd.myOcean.dto.member.request.MemberGenderRequest;
+import dnd.myOcean.dto.member.response.MemberResponseDto;
+import dnd.myOcean.service.sign.KakaoMemberDetailsService;
 import dnd.myOcean.service.token.TokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @RestController
@@ -14,9 +17,28 @@ import org.springframework.web.bind.annotation.RestController;
 public class SignController {
 
     private final TokenService tokenService;
+    private final KakaoMemberDetailsService kakaoMemberDetailsService;
 
     @GetMapping("/login/oauth2/code/kakao")
     public ResponseEntity kakaoCallback(@RequestParam("code") String code) {
         return new ResponseEntity(code, HttpStatus.OK);
+    }
+
+    @PatchMapping("/login/oauth2/{memberId}/birthday")
+    public ResponseEntity updateBirthday(@PathVariable("memberId") Long memberId,
+                                         @RequestBody MemberBirthdayRequest memberBirthday) {
+
+        Member member = kakaoMemberDetailsService.updateBirthday(memberId, memberBirthday);
+        MemberResponseDto memberResponseDto = new MemberResponseDto(member);
+        return new ResponseEntity<>(memberResponseDto, HttpStatus.OK);
+    }
+
+    @PatchMapping("/login/oauth2/{memberId}/gender")
+    public ResponseEntity updateGender(@PathVariable("memberId") Long memberId,
+                                       @RequestBody MemberGenderRequest memberGender) {
+
+        Member member = kakaoMemberDetailsService.updateGender(memberId, memberGender);
+        MemberResponseDto memberResponseDto = new MemberResponseDto(member);
+        return new ResponseEntity<>(memberResponseDto, HttpStatus.OK);
     }
 }

--- a/src/main/java/dnd/myOcean/domain/member/Gender.java
+++ b/src/main/java/dnd/myOcean/domain/member/Gender.java
@@ -1,0 +1,6 @@
+package dnd.myOcean.domain.member;
+
+public enum Gender {
+
+    MALE, FEMALE
+}

--- a/src/main/java/dnd/myOcean/domain/member/Member.java
+++ b/src/main/java/dnd/myOcean/domain/member/Member.java
@@ -1,6 +1,7 @@
 package dnd.myOcean.domain.member;
 
 import dnd.myOcean.domain.base.BaseEntity;
+import dnd.myOcean.dto.member.request.MemberBirthdayRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -24,4 +25,18 @@ public class Member extends BaseEntity {
 
     @Column
     private String nickName;
+
+    @Column
+    private String birthday;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    public void updateBirthday(MemberBirthdayRequest birthday) {
+        this.birthday = birthday.getBirthday();
+    }
+
+    public void updateGender(Gender gender) {
+        this.gender = gender;
+    }
 }

--- a/src/main/java/dnd/myOcean/dto/member/request/MemberBirthdayRequest.java
+++ b/src/main/java/dnd/myOcean/dto/member/request/MemberBirthdayRequest.java
@@ -1,0 +1,8 @@
+package dnd.myOcean.dto.member.request;
+
+import lombok.Getter;
+
+@Getter
+public class MemberBirthdayRequest {
+    private String birthday;
+}

--- a/src/main/java/dnd/myOcean/dto/member/request/MemberGenderRequest.java
+++ b/src/main/java/dnd/myOcean/dto/member/request/MemberGenderRequest.java
@@ -1,0 +1,8 @@
+package dnd.myOcean.dto.member.request;
+
+import lombok.Getter;
+
+@Getter
+public class MemberGenderRequest {
+    private String gender;
+}

--- a/src/main/java/dnd/myOcean/dto/member/response/MemberResponseDto.java
+++ b/src/main/java/dnd/myOcean/dto/member/response/MemberResponseDto.java
@@ -1,0 +1,28 @@
+package dnd.myOcean.dto.member.response;
+
+import dnd.myOcean.domain.member.Gender;
+import dnd.myOcean.domain.member.Member;
+import dnd.myOcean.domain.member.Role;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MemberResponseDto {
+
+    private Long id;
+    private String email;
+    private String nickname;
+    private String birthday;
+    private Gender gender;
+    private Role role;
+
+    public MemberResponseDto(Member member) {
+        this.id = member.getId();
+        this.email = member.getEmail();
+        this.nickname = member.getNickName();
+        this.birthday = member.getBirthday();
+        this.gender = member.getGender();
+        this.role = member.getRole();
+    }
+}

--- a/src/main/java/dnd/myOcean/service/sign/KakaoMemberDetailsService.java
+++ b/src/main/java/dnd/myOcean/service/sign/KakaoMemberDetailsService.java
@@ -2,8 +2,11 @@ package dnd.myOcean.service.sign;
 
 import dnd.myOcean.config.oAuth.kakao.KakaoMemberDetails;
 import dnd.myOcean.config.oAuth.kakao.KakaoUserInfo;
+import dnd.myOcean.domain.member.Gender;
 import dnd.myOcean.domain.member.Member;
 import dnd.myOcean.domain.member.Role;
+import dnd.myOcean.dto.member.request.MemberBirthdayRequest;
+import dnd.myOcean.dto.member.request.MemberGenderRequest;
 import dnd.myOcean.repository.MemberRepository;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +35,7 @@ public class KakaoMemberDetailsService extends DefaultOAuth2UserService {
                         memberRepository.save(
                                 Member.builder()
                                         .email(kakaoUserInfo.getEmail())
+                                        .nickName(kakaoUserInfo.getName())
                                         .role(Role.USER)
                                         .build()
                         )
@@ -42,5 +46,23 @@ public class KakaoMemberDetailsService extends DefaultOAuth2UserService {
         return new KakaoMemberDetails(String.valueOf(member.getId()),
                 Collections.singletonList(authority),
                 oAuth2User.getAttributes());
+    }
+
+    @Transactional
+    public Member updateBirthday(Long memberId, MemberBirthdayRequest memberBirthday) {
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        member.updateBirthday(memberBirthday);
+
+        return memberRepository.save(member);
+    }
+
+    @Transactional
+    public Member updateGender(Long memberId, MemberGenderRequest memberGender) {
+        Member member = memberRepository.findById(memberId).orElseThrow();
+
+        Gender gender = Gender.valueOf(memberGender.toString());
+        member.updateGender(Gender.valueOf(memberGender.toString()));
+
+        return memberRepository.save(member);
     }
 }


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 자동으로 닫을 이슈 번호를 작성해주세요 ex) #11 -->
- close #8 


## ✅ 작업 사항
카카오 로그인 중 성별, 생일 바인딩하는 기능 추가

## 👩‍💻 공유 포인트 및 논의 사항
- 아직 성별에 대한 바인딩은 구현 못함
- dto 패키지의 MemberRequest를 보면 생일과 성별에 대한 RequestDto가 다른 성격이라 네이밍을 달리하여 클래스를 만들었는데, 하나의 클래스로 할지 지금처럼 두개로 할지 고민
