### PR TITLE
Feature/#6 온보딩 페이징 기능 추가

### DIFF
--- a/src/main/java/dnd/myOcean/advisor/ExceptionAdvisor.java
+++ b/src/main/java/dnd/myOcean/advisor/ExceptionAdvisor.java
@@ -2,9 +2,7 @@ package dnd.myOcean.advisor;
 
 import dnd.myOcean.exception.auth.AccessDeniedException;
 import dnd.myOcean.exception.auth.AuthenticationEntryPointException;
-import dnd.myOcean.exception.member.BirthdayUpdateLimitExceedException;
-import dnd.myOcean.exception.member.GenderUpdateLimitExceedException;
-import dnd.myOcean.exception.member.NoSuchGenderException;
+import dnd.myOcean.exception.member.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -36,6 +34,18 @@ public class ExceptionAdvisor {
     @ResponseStatus(HttpStatus.NOT_MODIFIED)
     public ResponseEntity genderUpdateLimitExceedException(GenderUpdateLimitExceedException e) {
         return new ResponseEntity("성별 수정 가능한 횟수를 초과했습니다.", HttpStatus.NOT_MODIFIED);
+    }
+
+    @ExceptionHandler(NicknameUpdateLimitExceedException.class)
+    @ResponseStatus(HttpStatus.NOT_MODIFIED)
+    public ResponseEntity nicknameUpdateLimitExceedException(NicknameUpdateLimitExceedException e) {
+        return new ResponseEntity("닉네임 수정 가능한 횟수를 초과했습니다.", HttpStatus.NOT_MODIFIED);
+    }
+
+    @ExceptionHandler(WorryUpdateLimitExceedException.class)
+    @ResponseStatus(HttpStatus.NOT_MODIFIED)
+    public ResponseEntity worryUpdateLimitExceedException(WorryUpdateLimitExceedException e) {
+        return new ResponseEntity("고민 수정 가능한 횟수를 초과했습니다.", HttpStatus.NOT_MODIFIED);
     }
 
     @ExceptionHandler(NoSuchGenderException.class)

--- a/src/main/java/dnd/myOcean/controller/member/MemberController.java
+++ b/src/main/java/dnd/myOcean/controller/member/MemberController.java
@@ -1,10 +1,10 @@
 package dnd.myOcean.controller.member;
 
 
-import static dnd.myOcean.config.security.util.SecurityUtils.getCurrentEmail;
-
 import dnd.myOcean.dto.member.MemberBirthdayUpdateRequest;
 import dnd.myOcean.dto.member.MemberGenderUpdateRequest;
+import dnd.myOcean.dto.member.MemberNicknameUpdateRequest;
+import dnd.myOcean.dto.member.MemberWorryUpdateRequest;
 import dnd.myOcean.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static dnd.myOcean.config.security.util.SecurityUtils.getCurrentEmail;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,6 +32,18 @@ public class MemberController {
     @PatchMapping("/gender")
     public ResponseEntity updateGender(@RequestBody MemberGenderUpdateRequest memberGenderUpdateRequest) {
         memberService.updateGender(getCurrentEmail(), memberGenderUpdateRequest);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PatchMapping("/nick-name")
+    public ResponseEntity updateNickname(@RequestBody MemberNicknameUpdateRequest memberNicknameUpdateRequest) {
+        memberService.updateNickname(getCurrentEmail(), memberNicknameUpdateRequest);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PatchMapping("/worry")
+    public ResponseEntity updateWorry(@RequestBody MemberWorryUpdateRequest memberWorryUpdateRequest) {
+        memberService.updateWorry(getCurrentEmail(), memberWorryUpdateRequest);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/dnd/myOcean/domain/member/Member.java
+++ b/src/main/java/dnd/myOcean/domain/member/Member.java
@@ -1,19 +1,15 @@
 package dnd.myOcean.domain.member;
 
 import dnd.myOcean.domain.base.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import java.time.LocalDate;
-import java.time.Period;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.List;
 
 @Entity
 @Getter
@@ -41,11 +37,21 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
+    @ElementCollection(targetClass = Worry.class) // JPA가 해당 필드를 컬렉션으로 관리하기 위한 어노테이션
+    @Enumerated(EnumType.STRING)
+    private List<Worry> worry;
+
     @Column
     private Integer updatedAge;
 
     @Column
     private Integer updatedGender;
+
+    @Column
+    private Integer updateNickname;
+
+    @Column
+    private Integer updateWorry;
 
     public void updateAge(final String birthday) {
         LocalDate birthDay = LocalDate.parse(birthday);
@@ -59,12 +65,26 @@ public class Member extends BaseEntity {
         this.updatedGender++;
     }
 
+    public void updateNickname(final String nickname) {
+        this.nickName = nickname;
+        this.updateNickname++;
+    }
+
+    public void updateWorry(final List<Worry> worries) {
+        this.worry = worries;
+        this.updateWorry = worries.size();
+    }
+
     public boolean isBirthDayChangeLimitExceeded() {
         return updatedAge >= 2;
     }
 
     public boolean isGenderChangeLimitExceeded() {
         return updatedGender >= 2;
+    }
+
+    public boolean isNicknameChangeLimitExceeded() {
+        return updateNickname >= 2;
     }
 
     private static Integer calculateAge(LocalDate birthday, LocalDate currentDate) {

--- a/src/main/java/dnd/myOcean/domain/member/Worry.java
+++ b/src/main/java/dnd/myOcean/domain/member/Worry.java
@@ -1,0 +1,17 @@
+package dnd.myOcean.domain.member;
+
+import dnd.myOcean.exception.member.NoSuchGenderException;
+
+public enum Worry {
+    WORK, COURSE, RELATIONSHIP, BREAK_LOVE,
+    LOVE, STUDY, FAMILY, ETC;
+
+    public static Worry from(String value) {
+        for (Worry worry : Worry.values()) {
+            if (worry.name().equalsIgnoreCase(value)) {
+                return worry;
+            }
+        }
+        throw new NoSuchGenderException();
+    }
+}

--- a/src/main/java/dnd/myOcean/dto/member/MemberNicknameUpdateRequest.java
+++ b/src/main/java/dnd/myOcean/dto/member/MemberNicknameUpdateRequest.java
@@ -1,0 +1,11 @@
+package dnd.myOcean.dto.member;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberNicknameUpdateRequest {
+
+    private String nickname;
+}

--- a/src/main/java/dnd/myOcean/dto/member/MemberWorryUpdateRequest.java
+++ b/src/main/java/dnd/myOcean/dto/member/MemberWorryUpdateRequest.java
@@ -1,0 +1,24 @@
+package dnd.myOcean.dto.member;
+
+import dnd.myOcean.domain.member.Worry;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class MemberWorryUpdateRequest {
+
+    private List<String> worries;
+
+    public List<Worry> getWorries() {
+        List<Worry> store = new ArrayList<>();
+        for (String worry : worries) {
+            Worry findWorry = Worry.from(worry);
+            store.add(findWorry);
+        }
+        return store;
+    }
+}

--- a/src/main/java/dnd/myOcean/exception/member/NicknameUpdateLimitExceedException.java
+++ b/src/main/java/dnd/myOcean/exception/member/NicknameUpdateLimitExceedException.java
@@ -1,0 +1,4 @@
+package dnd.myOcean.exception.member;
+
+public class NicknameUpdateLimitExceedException extends RuntimeException{
+}

--- a/src/main/java/dnd/myOcean/exception/member/WorryUpdateLimitExceedException.java
+++ b/src/main/java/dnd/myOcean/exception/member/WorryUpdateLimitExceedException.java
@@ -1,0 +1,4 @@
+package dnd.myOcean.exception.member;
+
+public class WorryUpdateLimitExceedException extends RuntimeException{
+}

--- a/src/main/java/dnd/myOcean/service/member/MemberService.java
+++ b/src/main/java/dnd/myOcean/service/member/MemberService.java
@@ -3,15 +3,19 @@ package dnd.myOcean.service.member;
 
 import dnd.myOcean.domain.member.Gender;
 import dnd.myOcean.domain.member.Member;
+import dnd.myOcean.domain.member.Worry;
 import dnd.myOcean.dto.member.MemberBirthdayUpdateRequest;
 import dnd.myOcean.dto.member.MemberGenderUpdateRequest;
-import dnd.myOcean.exception.member.BirthdayUpdateLimitExceedException;
-import dnd.myOcean.exception.member.GenderUpdateLimitExceedException;
-import dnd.myOcean.exception.member.MemberNotFoundException;
+import dnd.myOcean.dto.member.MemberNicknameUpdateRequest;
+import dnd.myOcean.dto.member.MemberWorryUpdateRequest;
+import dnd.myOcean.exception.member.*;
 import dnd.myOcean.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -42,6 +46,32 @@ public class MemberService {
         }
 
         member.updateGender(Gender.from(memberGenderUpdateRequest.getGender()));
+    }
+
+    @Transactional
+    public void updateNickname(final String email, final MemberNicknameUpdateRequest memberNicknameUpdateRequest) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(MemberNotFoundException::new);
+
+        if(member.isNicknameChangeLimitExceeded()){
+            throw new NicknameUpdateLimitExceedException();
+        }
+
+        member.updateNickname(memberNicknameUpdateRequest.getNickname());
+    }
+
+    @Transactional
+    public void updateWorry(final String email, final MemberWorryUpdateRequest memberWorryUpdateRequest) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(MemberNotFoundException::new);
+
+        List<Worry> worries = memberWorryUpdateRequest.getWorries();
+
+        if(worries.size() > 3) {
+            throw new WorryUpdateLimitExceedException();
+        }
+
+        member.updateWorry(worries);
     }
 }
 


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 자동으로 닫을 이슈 번호를 작성해주세요 ex) #11 -->
- close #이슈번호
close #6 

## ✅ 작업 사항
닉네임 수정 기능
고민 수정 기능

## 👩‍💻 공유 포인트 및 논의 사항
- `Member` 엔티티에서 `@ElementCollection` 라는 어노테이션을 써서 JPA가 컬렉션을 관리하게끔 만들었는데 좋은 방법인거는 잘 모르겠음 (실행은 문제 없이 됨)
- 고민에 대한 enum에서 네이밍을 하기는 했는데, 좀더 좋은 네이밍이 있을 것 같음
- 서비스 단에서 고민에 대한 요청의 갯수가 3개보다 클 경우 예외 처리를 하였음
