### PR TITLE
Refactor/#37 JWT 만료 엔드포인트 설정

### DIFF
--- a/src/main/java/dnd/myOcean/domain/member/api/AuthController.java
+++ b/src/main/java/dnd/myOcean/domain/member/api/AuthController.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import dnd.myOcean.domain.member.application.AuthService;
 import dnd.myOcean.global.auth.jwt.token.TokenResponse;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -45,10 +44,6 @@ public class AuthController {
      */
     @GetMapping("/reissue")
     public ResponseEntity<TokenResponse> reissueToken(HttpServletRequest request) {
-        HttpSession session = request.getSession();
-        String accessToken = (String) session.getAttribute("accessToken");
-        String refreshToken = (String) session.getAttribute("refreshToken");
-
-        return new ResponseEntity(new TokenResponse(accessToken, refreshToken), HttpStatus.OK);
+        return new ResponseEntity<>(authService.reissueAccessToken(request), HttpStatus.OK);
     }
 }

--- a/src/main/java/dnd/myOcean/domain/member/application/AuthService.java
+++ b/src/main/java/dnd/myOcean/domain/member/application/AuthService.java
@@ -166,28 +166,29 @@ public class AuthService {
 
     public TokenResponse reissueAccessToken(HttpServletRequest request) {
         String refreshToken = getTokenFromHeader(request, REFRESH_HEADER);
-        if (tokenProvider.validate(refreshToken) && tokenProvider.validateExpire(refreshToken)) {
-            RefreshToken findToken = refreshTokenRedisRepository.findByRefreshToken(refreshToken);
 
-            TokenResponse tokenResponse = tokenProvider.createToken(
-                    String.valueOf(findToken.getId()),
-                    findToken.getEmail(),
-                    findToken.getAuthority());
-
-            refreshTokenRedisRepository.save(RefreshToken.builder()
-                    .id(findToken.getId())
-                    .email(findToken.getEmail())
-                    .authorities(findToken.getAuthorities())
-                    .refreshToken(tokenResponse.getRefreshToken())
-                    .build());
-
-            SecurityContextHolder.getContext()
-                    .setAuthentication(tokenProvider.getAuthentication(tokenResponse.getAccessToken()));
-
-            return tokenResponse;
+        if (!tokenProvider.validate(refreshToken) || !tokenProvider.validateExpire(refreshToken)) {
+            throw new ReissueFailException();
         }
-        
-        throw new ReissueFailException();
+
+        RefreshToken findToken = refreshTokenRedisRepository.findByRefreshToken(refreshToken);
+
+        TokenResponse tokenResponse = tokenProvider.createToken(
+                String.valueOf(findToken.getId()),
+                findToken.getEmail(),
+                findToken.getAuthority());
+
+        refreshTokenRedisRepository.save(RefreshToken.builder()
+                .id(findToken.getId())
+                .email(findToken.getEmail())
+                .authorities(findToken.getAuthorities())
+                .refreshToken(tokenResponse.getRefreshToken())
+                .build());
+
+        SecurityContextHolder.getContext()
+                .setAuthentication(tokenProvider.getAuthentication(tokenResponse.getAccessToken()));
+
+        return tokenResponse;
     }
 
     private String getTokenFromHeader(HttpServletRequest request, String headerName) {

--- a/src/main/java/dnd/myOcean/domain/member/application/AuthService.java
+++ b/src/main/java/dnd/myOcean/domain/member/application/AuthService.java
@@ -9,10 +9,12 @@ import dnd.myOcean.domain.member.domain.Role;
 import dnd.myOcean.domain.member.domain.dto.request.KakaoLoginRequest;
 import dnd.myOcean.domain.member.repository.infra.jpa.MemberRepository;
 import dnd.myOcean.global.auth.exception.auth.InvalidAuthCodeException;
+import dnd.myOcean.global.auth.exception.auth.ReissueFailException;
 import dnd.myOcean.global.auth.jwt.token.TokenProvider;
 import dnd.myOcean.global.auth.jwt.token.TokenResponse;
 import dnd.myOcean.global.auth.jwt.token.repository.redis.RefreshTokenRedisRepository;
 import dnd.myOcean.global.common.auth.RefreshToken;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -22,9 +24,11 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
@@ -32,6 +36,7 @@ import org.springframework.web.client.RestTemplate;
 @RequiredArgsConstructor
 public class AuthService {
 
+    private static final String REFRESH_HEADER = "RefreshToken";
     private static final String PREFIX = "낯선 ";
 
     private final RestTemplate restTemplate;
@@ -157,5 +162,25 @@ public class AuthService {
         } catch (HttpClientErrorException e) {
             throw new InvalidAuthCodeException();
         }
+    }
+
+    public TokenResponse reissueAccessToken(HttpServletRequest request) {
+        String refreshToken = getTokenFromHeader(request, REFRESH_HEADER);
+        if (tokenProvider.validate(refreshToken) && tokenProvider.validateExpire(refreshToken)) {
+            TokenResponse tokenResponse = tokenProvider.reIssueAccessToken(refreshToken);
+            SecurityContextHolder.getContext()
+                    .setAuthentication(tokenProvider.getAuthentication(tokenResponse.getAccessToken()));
+            return tokenResponse;
+        }
+
+        throw new ReissueFailException();
+    }
+
+    private String getTokenFromHeader(HttpServletRequest request, String headerName) {
+        String token = request.getHeader(headerName);
+        if (StringUtils.hasText(token)) {
+            return token;
+        }
+        return null;
     }
 }

--- a/src/main/java/dnd/myOcean/global/auth/aop/AssignCurrentMemberIdAspect.java
+++ b/src/main/java/dnd/myOcean/global/auth/aop/AssignCurrentMemberIdAspect.java
@@ -3,7 +3,6 @@ package dnd.myOcean.global.auth.aop;
 
 import dnd.myOcean.global.auth.exception.auth.AccessDeniedException;
 import dnd.myOcean.global.auth.exception.auth.AuthenticationEntryPointException;
-import dnd.myOcean.global.auth.exception.auth.IllegalAuthenticationException;
 import dnd.myOcean.global.auth.oauth.kakao.details.KakaoMemberDetails;
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -66,6 +65,6 @@ public class AssignCurrentMemberIdAspect {
             throw new AuthenticationEntryPointException();
         }
 
-        throw new IllegalAuthenticationException();
+        throw new AuthenticationEntryPointException();
     }
 }

--- a/src/main/java/dnd/myOcean/global/auth/exception/auth/AccessTokenExpiredException.java
+++ b/src/main/java/dnd/myOcean/global/auth/exception/auth/AccessTokenExpiredException.java
@@ -1,0 +1,4 @@
+package dnd.myOcean.global.auth.exception.auth;
+
+public class AccessTokenExpiredException extends RuntimeException {
+}

--- a/src/main/java/dnd/myOcean/global/auth/exception/auth/IllegalAuthenticationException.java
+++ b/src/main/java/dnd/myOcean/global/auth/exception/auth/IllegalAuthenticationException.java
@@ -1,4 +1,0 @@
-package dnd.myOcean.global.auth.exception.auth;
-
-public class IllegalAuthenticationException extends RuntimeException {
-}

--- a/src/main/java/dnd/myOcean/global/auth/exception/auth/InvalidTokenException.java
+++ b/src/main/java/dnd/myOcean/global/auth/exception/auth/InvalidTokenException.java
@@ -1,4 +1,0 @@
-package dnd.myOcean.global.auth.exception.auth;
-
-public class InvalidTokenException extends RuntimeException {
-}

--- a/src/main/java/dnd/myOcean/global/auth/exception/auth/ReissueFailException.java
+++ b/src/main/java/dnd/myOcean/global/auth/exception/auth/ReissueFailException.java
@@ -1,8 +1,4 @@
 package dnd.myOcean.global.auth.exception.auth;
 
 public class ReissueFailException extends RuntimeException {
-
-    public ReissueFailException(String message) {
-        super(message);
-    }
 }

--- a/src/main/java/dnd/myOcean/global/auth/exception/handler/AuthExceptionController.java
+++ b/src/main/java/dnd/myOcean/global/auth/exception/handler/AuthExceptionController.java
@@ -1,6 +1,7 @@
-package dnd.myOcean.global.auth.exception;
+package dnd.myOcean.global.auth.exception.handler;
 
 import dnd.myOcean.global.auth.exception.auth.AccessDeniedException;
+import dnd.myOcean.global.auth.exception.auth.AccessTokenExpiredException;
 import dnd.myOcean.global.auth.exception.auth.AuthenticationEntryPointException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,5 +19,10 @@ public class AuthExceptionController {
     @GetMapping("/entry-point")
     public void authenticateException() {
         throw new AuthenticationEntryPointException();
+    }
+
+    @GetMapping("/access-token-expired")
+    public void accessTokenExpiredException() {
+        throw new AccessTokenExpiredException();
     }
 }

--- a/src/main/java/dnd/myOcean/global/auth/exception/handler/AuthExceptionHandler.java
+++ b/src/main/java/dnd/myOcean/global/auth/exception/handler/AuthExceptionHandler.java
@@ -1,8 +1,10 @@
 package dnd.myOcean.global.auth.exception.handler;
 
 import dnd.myOcean.global.auth.exception.auth.AccessDeniedException;
+import dnd.myOcean.global.auth.exception.auth.AccessTokenExpiredException;
 import dnd.myOcean.global.auth.exception.auth.AuthenticationEntryPointException;
 import dnd.myOcean.global.auth.exception.auth.InvalidAuthCodeException;
+import dnd.myOcean.global.auth.exception.auth.ReissueFailException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -27,7 +29,19 @@ public class AuthExceptionHandler {
 
     @ExceptionHandler(InvalidAuthCodeException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    public ResponseEntity InvalidAuthCodeException(InvalidAuthCodeException e) {
+    public ResponseEntity invalidAuthCodeException(InvalidAuthCodeException e) {
         return new ResponseEntity("유효하지 않은 인가 코드입니다.", HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(AccessTokenExpiredException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ResponseEntity accessTokenExpiredException(AccessTokenExpiredException e) {
+        return new ResponseEntity("액세스 토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(ReissueFailException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ResponseEntity reissueFailException(ReissueFailException e) {
+        return new ResponseEntity("리프레시 토큰이 올바르지 않습니다. 다시 로그인해주세요.", HttpStatus.UNAUTHORIZED);
     }
 }

--- a/src/main/java/dnd/myOcean/global/auth/jwt/filter/JwtFilter.java
+++ b/src/main/java/dnd/myOcean/global/auth/jwt/filter/JwtFilter.java
@@ -31,15 +31,14 @@ public class JwtFilter extends OncePerRequestFilter {
         }
 
         String accessToken = getTokenFromHeader(request, ACCESS_HEADER);
-
-        if (tokenProvider.validateExpire(accessToken) && tokenProvider.validate(accessToken)) {
-            SecurityContextHolder.getContext().setAuthentication(tokenProvider.getAuthentication(accessToken));
-            return;
-        }
-
+        
         if (!tokenProvider.validateExpire(accessToken) && tokenProvider.validate(accessToken)) {
             response.sendRedirect("/api/exception/access-token-expired");
             return;
+        }
+
+        if (tokenProvider.validateExpire(accessToken) && tokenProvider.validate(accessToken)) {
+            SecurityContextHolder.getContext().setAuthentication(tokenProvider.getAuthentication(accessToken));
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/dnd/myOcean/global/auth/jwt/token/TokenProvider.java
+++ b/src/main/java/dnd/myOcean/global/auth/jwt/token/TokenProvider.java
@@ -139,6 +139,7 @@ public class TokenProvider {
 
         TokenResponse tokenResponse = createToken(String.valueOf(findToken.getId()), findToken.getEmail(),
                 findToken.getAuthority());
+        
         refreshTokenRedisRepository.save(RefreshToken.builder()
                 .id(findToken.getId())
                 .authorities(findToken.getAuthorities())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,5 +62,5 @@ spring:
 
 jwt:
   secret_key: ${jwt.secret_key}
-  access-token-validity-in-seconds: 30000 # (배포 시 30분 -> 1800 설정)
+  access-token-validity-in-seconds: 15 # (배포 시 30분 -> 1800 설정)
   refresh-token-validity-in-seconds: 86400 # (배포 시 1일 -> 86400설정)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,5 +62,5 @@ spring:
 
 jwt:
   secret_key: ${jwt.secret_key}
-  access-token-validity-in-seconds: 15 # (배포 시 30분 -> 1800 설정)
+  access-token-validity-in-seconds: 86400 # (배포 시 30분 -> 1800 설정)
   refresh-token-validity-in-seconds: 86400 # (배포 시 1일 -> 86400설정)


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 자동으로 닫을 이슈 번호를 작성해주세요 ex) #11 -->
- close #37 
- 


## ✅ 작업 사항
✅ JWT 만료 엔드포인트 설정
- 액세스 토큰 만료 시, 자동으로 리다이렉션을 통해 액세스 토큰을 재발급받는 로직에서 -> 예외를 던지는 방식으로 변경
- 액세스 토큰을 재발급받는 API를 별도로 구현



## 👩‍💻 공유 포인트 및 논의 사항
