### PR TITLE
Feature/#41 편지에 이미지 첨부 기능 추가, 관리되지 않는 편지 데이터 - 스케줄러 일괄삭제 처리

### DIFF
--- a/src/main/java/dnd/myOcean/MyOceanApplication.java
+++ b/src/main/java/dnd/myOcean/MyOceanApplication.java
@@ -5,11 +5,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAspectJAutoProxy
 @EnableJpaAuditing
 @EnableAsync
+@EnableScheduling
 public class MyOceanApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/dnd/myOcean/domain/letter/api/LetterController.java
+++ b/src/main/java/dnd/myOcean/domain/letter/api/LetterController.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,7 +35,7 @@ public class LetterController {
     // 0. 편지 전송
     @PostMapping
     @AssignCurrentMemberId
-    public ResponseEntity<Void> send(@RequestBody LetterSendRequest request) {
+    public ResponseEntity<Void> send(@ModelAttribute LetterSendRequest request) {
         letterService.send(request);
         return new ResponseEntity(HttpStatus.CREATED);
     }

--- a/src/main/java/dnd/myOcean/domain/letter/application/LetterService.java
+++ b/src/main/java/dnd/myOcean/domain/letter/application/LetterService.java
@@ -119,14 +119,7 @@ public class LetterService {
     private List<Letter> createLetters(LetterSendRequest request, List<Member> receivers, Member sender,
                                        int letterCount) {
         MultipartFile image = request.getImage();
-
-        LetterImage letterImage;
-        if (!image.isEmpty()) {
-            fileService.upload(image, image.getOriginalFilename());
-            letterImage = new LetterImage(image.getOriginalFilename());
-        } else {
-            letterImage = null;
-        }
+        LetterImage letterImage = getLetterImage(image);
 
         String letterUuid = String.valueOf(UUID.randomUUID());
         return IntStream.range(0, letterCount)
@@ -138,6 +131,16 @@ public class LetterService {
                         letterImage,
                         letterUuid))
                 .collect(Collectors.toList());
+    }
+
+    private LetterImage getLetterImage(MultipartFile image) {
+        LetterImage letterImage;
+        if (image != null) {
+            fileService.upload(image, image.getOriginalFilename());
+            letterImage = new LetterImage(image.getOriginalFilename());
+            return letterImage;
+        }
+        return null;
     }
 
     private int generateRandomReceiverCount(Integer maxCount) {

--- a/src/main/java/dnd/myOcean/domain/letter/domain/Letter.java
+++ b/src/main/java/dnd/myOcean/domain/letter/domain/Letter.java
@@ -1,9 +1,11 @@
 package dnd.myOcean.domain.letter.domain;
 
 
+import dnd.myOcean.domain.letterimage.domain.LetterImage;
 import dnd.myOcean.domain.member.domain.Member;
 import dnd.myOcean.domain.member.domain.WorryType;
 import dnd.myOcean.global.common.base.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -50,6 +52,11 @@ public class Letter extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private WorryType worryType;
 
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "letter_image_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private LetterImage letterImage;
+
     private boolean isDeleteBySender;
     private boolean hasReplied;
     private boolean isStored;
@@ -57,12 +64,13 @@ public class Letter extends BaseEntity {
     private String uuid;
 
     public static Letter createLetter(Member sender, String content, Member receiver, WorryType worryType,
-                                      String uuid) {
+                                      LetterImage letterImage, String uuid) {
         return Letter.builder()
                 .sender(sender)
                 .content(content)
                 .receiver(receiver)
                 .worryType(worryType)
+                .letterImage(letterImage)
                 .uuid(uuid)
                 .isDeleteBySender(false)
                 .hasReplied(false)

--- a/src/main/java/dnd/myOcean/domain/letter/domain/Letter.java
+++ b/src/main/java/dnd/myOcean/domain/letter/domain/Letter.java
@@ -54,7 +54,6 @@ public class Letter extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "letter_image_id")
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private LetterImage letterImage;
 
     private boolean isDeleteBySender;

--- a/src/main/java/dnd/myOcean/domain/letter/domain/dto/request/LetterSendRequest.java
+++ b/src/main/java/dnd/myOcean/domain/letter/domain/dto/request/LetterSendRequest.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 @Data
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -14,10 +15,7 @@ public class LetterSendRequest {
 
     @Null
     private Long memberId;
-
-    @NotEmpty(message = "편지 내용을 입력해주세요.")
-    private String content;
-
+    
     private boolean equalGender;
 
     @NotEmpty(message = "수신자의 최소 나이를 지정해주세요.")
@@ -28,4 +26,9 @@ public class LetterSendRequest {
 
     @NotEmpty
     private String worryType;
+
+    @NotEmpty(message = "편지 내용을 입력해주세요.")
+    private String content;
+
+    private MultipartFile image;
 }

--- a/src/main/java/dnd/myOcean/domain/letter/domain/dto/request/LetterSendRequest.java
+++ b/src/main/java/dnd/myOcean/domain/letter/domain/dto/request/LetterSendRequest.java
@@ -1,5 +1,6 @@
 package dnd.myOcean.domain.letter.domain.dto.request;
 
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Null;
 import lombok.AccessLevel;
@@ -15,7 +16,7 @@ public class LetterSendRequest {
 
     @Null
     private Long memberId;
-    
+
     private boolean equalGender;
 
     @NotEmpty(message = "수신자의 최소 나이를 지정해주세요.")
@@ -30,5 +31,6 @@ public class LetterSendRequest {
     @NotEmpty(message = "편지 내용을 입력해주세요.")
     private String content;
 
+    @Nullable
     private MultipartFile image;
 }

--- a/src/main/java/dnd/myOcean/domain/letter/repository/infra/jpa/LetterRepository.java
+++ b/src/main/java/dnd/myOcean/domain/letter/repository/infra/jpa/LetterRepository.java
@@ -2,9 +2,11 @@ package dnd.myOcean.domain.letter.repository.infra.jpa;
 
 import dnd.myOcean.domain.letter.domain.Letter;
 import dnd.myOcean.domain.letter.repository.infra.querydsl.LetterQuerydslRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -35,4 +37,8 @@ public interface LetterRepository extends JpaRepository<Letter, Long>, LetterQue
 
     @Query("SELECT l FROM Letter l WHERE l.uuid = :uuid")
     List<Letter> findAllByUuid(@Param("uuid") String uuid);
+
+    @Modifying
+    @Query("DELETE FROM Letter l WHERE l.createDate <= :expirationDate and l.hasReplied = false")
+    void deleteDiscardedLetters(@Param("expirationDate") LocalDateTime expirationDate);
 }

--- a/src/main/java/dnd/myOcean/domain/letter/scheduler/LetterScheduler.java
+++ b/src/main/java/dnd/myOcean/domain/letter/scheduler/LetterScheduler.java
@@ -1,0 +1,22 @@
+package dnd.myOcean.domain.letter.scheduler;
+
+import dnd.myOcean.domain.letter.repository.infra.jpa.LetterRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class LetterScheduler {
+
+    private final LetterRepository letterRepository;
+
+    @Transactional
+    @Scheduled(fixedRate = 600000) // 600000 mill second = 10 min
+    public void deleteDiscardedLetters() {
+        LocalDateTime expiredDate = LocalDateTime.now().minusHours(48);
+        letterRepository.deleteDiscardedLetters(expiredDate);
+    }
+}

--- a/src/main/java/dnd/myOcean/domain/letterimage/application/FileService.java
+++ b/src/main/java/dnd/myOcean/domain/letterimage/application/FileService.java
@@ -1,0 +1,34 @@
+package dnd.myOcean.domain.letterimage.application;
+
+import dnd.myOcean.domain.letterimage.exception.FileUploadFailureException;
+import jakarta.annotation.PostConstruct;
+import java.io.File;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class FileService {
+
+    @Value("${upload.image.location}")
+    private String location;
+
+    @PostConstruct
+    void postConstruct() { // 2
+        File dir = new File(location);
+        if (!dir.exists()) {
+            dir.mkdir();
+        }
+    }
+
+    public void upload(MultipartFile file, String filename) {
+        try {
+            file.transferTo(new File(location + filename));
+        } catch (IOException e) {
+            throw new FileUploadFailureException();
+        }
+    }
+}

--- a/src/main/java/dnd/myOcean/domain/letterimage/application/FileService.java
+++ b/src/main/java/dnd/myOcean/domain/letterimage/application/FileService.java
@@ -1,6 +1,6 @@
 package dnd.myOcean.domain.letterimage.application;
 
-import dnd.myOcean.domain.letterimage.exception.FileUploadFailureException;
+import dnd.myOcean.global.exception.UnknownException;
 import jakarta.annotation.PostConstruct;
 import java.io.File;
 import java.io.IOException;
@@ -28,7 +28,7 @@ public class FileService {
         try {
             file.transferTo(new File(location + filename));
         } catch (IOException e) {
-            throw new FileUploadFailureException();
+            throw new UnknownException();
         }
     }
 }

--- a/src/main/java/dnd/myOcean/domain/letterimage/domain/LetterImage.java
+++ b/src/main/java/dnd/myOcean/domain/letterimage/domain/LetterImage.java
@@ -1,0 +1,64 @@
+package dnd.myOcean.domain.letterimage.domain;
+
+
+import dnd.myOcean.domain.letterimage.exception.NoExtException;
+import dnd.myOcean.domain.letterimage.exception.UnSupportExtException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.util.Arrays;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LetterImage {
+
+    private static final String[] extension = {"jpg", "jpeg", "gif", "bmp", "png"};
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "letter_image_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String uniqueName;
+
+    @Column(nullable = false)
+    private String originName;
+
+    public LetterImage(String originName) {
+        this.originName = originName;
+        this.uniqueName = extractExtAndGenerateUniqueName(originName);
+    }
+
+    private String extractExtAndGenerateUniqueName(String originName) {
+        String ext = getExt(originName);
+        return UUID.randomUUID() + "." + ext;
+    }
+
+    private String getExt(String originName) {
+        try {
+            String ext = originName.substring(originName.lastIndexOf(".") + 1);
+            if (supportFormat(ext)) {
+                return ext;
+            } else {
+                throw new UnSupportExtException();
+            }
+        } catch (StringIndexOutOfBoundsException e) {
+            throw new NoExtException();
+        } catch (UnSupportExtException e) {
+            throw e;
+        }
+    }
+
+    private boolean supportFormat(String ext) {
+        return Arrays.stream(extension)
+                .anyMatch(e -> e.equalsIgnoreCase(ext));
+    }
+}

--- a/src/main/java/dnd/myOcean/domain/letterimage/exception/FileUploadFailureException.java
+++ b/src/main/java/dnd/myOcean/domain/letterimage/exception/FileUploadFailureException.java
@@ -1,4 +1,0 @@
-package dnd.myOcean.domain.letterimage.exception;
-
-public class FileUploadFailureException extends RuntimeException {
-}

--- a/src/main/java/dnd/myOcean/domain/letterimage/exception/FileUploadFailureException.java
+++ b/src/main/java/dnd/myOcean/domain/letterimage/exception/FileUploadFailureException.java
@@ -1,0 +1,4 @@
+package dnd.myOcean.domain.letterimage.exception;
+
+public class FileUploadFailureException extends RuntimeException {
+}

--- a/src/main/java/dnd/myOcean/domain/letterimage/exception/NoExtException.java
+++ b/src/main/java/dnd/myOcean/domain/letterimage/exception/NoExtException.java
@@ -1,0 +1,4 @@
+package dnd.myOcean.domain.letterimage.exception;
+
+public class NoExtException extends RuntimeException {
+}

--- a/src/main/java/dnd/myOcean/domain/letterimage/exception/UnSupportExtException.java
+++ b/src/main/java/dnd/myOcean/domain/letterimage/exception/UnSupportExtException.java
@@ -1,0 +1,4 @@
+package dnd.myOcean.domain.letterimage.exception;
+
+public class UnSupportExtException extends RuntimeException {
+}

--- a/src/main/java/dnd/myOcean/domain/letterimage/exception/handler/LetterImageExceptionHandler.java
+++ b/src/main/java/dnd/myOcean/domain/letterimage/exception/handler/LetterImageExceptionHandler.java
@@ -1,0 +1,26 @@
+package dnd.myOcean.domain.letterimage.exception.handler;
+
+import dnd.myOcean.domain.letterimage.exception.NoExtException;
+import dnd.myOcean.domain.letterimage.exception.UnSupportExtException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class LetterImageExceptionHandler {
+
+    @ExceptionHandler(UnSupportExtException.class)
+    @ResponseStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+    public ResponseEntity unSupportExtException(UnSupportExtException e) {
+        return new ResponseEntity("업로드 하신 이미지는 지원하지 않는 파일 형식입니다. "
+                + "이미지가 png, jpg, jpeg, gif, bmp의 형식인지 확인해주세요.", HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    @ExceptionHandler(NoExtException.class)
+    @ResponseStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+    public ResponseEntity noExtException(NoExtException e) {
+        return new ResponseEntity("업로드 하신 이미지에 확장자가 존재하지 않습니다. ", HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,3 +64,7 @@ jwt:
   secret_key: ${jwt.secret_key}
   access-token-validity-in-seconds: 86400 # (배포 시 30분 -> 1800 설정)
   refresh-token-validity-in-seconds: 86400 # (배포 시 1일 -> 86400설정)
+
+upload:
+  image:
+    location: ${local.image.location}


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 자동으로 닫을 이슈 번호를 작성해주세요 ex) #11 -->
- close #41 


## ✅ 작업 사항

편지에 이미지 첨부 기능 추가  // local 환경에서 정상적으로 수행되도록 설정. 배포 이후 S3버킷으로 변경해야함
관리되지 않는 편지 데이터 - 스케줄러 일괄삭제 처리 // 48시간이 지났고, 답장이 없는 편지에 대하여 스케줄러를 10분 주기로 설정하여 일괄 삭제하도록 처리 


## 👩‍💻 공유 포인트 및 논의 사항
