### PR TITLE
Feature/#54 S3 버킷을 이용한 이미지 등록 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,12 @@ dependencies {
 
     // mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    // s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    // resizing
+    implementation 'net.coobird:thumbnailator:0.4.19'
 }
 
 tasks.named('test') {

--- a/src/main/java/dnd/myOcean/domain/letter/api/LetterController.java
+++ b/src/main/java/dnd/myOcean/domain/letter/api/LetterController.java
@@ -12,18 +12,13 @@ import dnd.myOcean.domain.letter.repository.infra.querydsl.dto.PagedRepliedLette
 import dnd.myOcean.domain.letter.repository.infra.querydsl.dto.PagedSendLettersResponse;
 import dnd.myOcean.global.auth.aop.AssignCurrentMemberId;
 import dnd.myOcean.global.auth.aop.dto.CurrentMemberIdRequest;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,7 +30,7 @@ public class LetterController {
     // 0. 편지 전송
     @PostMapping
     @AssignCurrentMemberId
-    public ResponseEntity<Void> send(@ModelAttribute LetterSendRequest request) {
+    public ResponseEntity<Void> send(@ModelAttribute LetterSendRequest request) throws IOException {
         letterService.send(request);
         return new ResponseEntity(HttpStatus.CREATED);
     }

--- a/src/main/java/dnd/myOcean/domain/letterimage/application/FileService.java
+++ b/src/main/java/dnd/myOcean/domain/letterimage/application/FileService.java
@@ -1,34 +1,56 @@
 package dnd.myOcean.domain.letterimage.application;
 
-import dnd.myOcean.global.exception.UnknownException;
-import jakarta.annotation.PostConstruct;
-import java.io.File;
-import java.io.IOException;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import lombok.RequiredArgsConstructor;
+import net.coobird.thumbnailator.Thumbnails;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 @Service
 @RequiredArgsConstructor
 public class FileService {
 
-    @Value("${upload.image.location}")
-    private String location;
+    private final AmazonS3Client amazonS3Client;
 
-    @PostConstruct
-    void postConstruct() { // 2
-        File dir = new File(location);
-        if (!dir.exists()) {
-            dir.mkdir();
-        }
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.url}")
+    private String bucketUrl;
+
+    @Transactional
+    public String uploadImage(MultipartFile file) throws IOException {
+        String requestTypeSimpleName = "letter" + "/";
+        String imageName = file.getOriginalFilename();
+        String fileName = requestTypeSimpleName + file.getOriginalFilename();
+
+        uploadResizedImage(bucket, fileName, file);
+
+        return bucketUrl + requestTypeSimpleName + imageName;
     }
 
-    public void upload(MultipartFile file, String filename) {
-        try {
-            file.transferTo(new File(location + filename));
-        } catch (IOException e) {
-            throw new UnknownException();
-        }
+    private void uploadResizedImage(String bucketName, String fileName, MultipartFile image) throws IOException {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(image.getContentType());
+        metadata.setContentLength(image.getSize());
+
+        byte[] buffer = getResizedImageStream(image);
+        metadata.setContentLength(buffer.length);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(buffer);
+
+        amazonS3Client.putObject(bucketName, fileName, inputStream, metadata);
+    }
+
+    private byte[] getResizedImageStream(MultipartFile image) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        Thumbnails.of(image.getInputStream()).size(400, 400).toOutputStream(outputStream);
+        return outputStream.toByteArray();
     }
 }

--- a/src/main/java/dnd/myOcean/domain/letterimage/application/FileService.java
+++ b/src/main/java/dnd/myOcean/domain/letterimage/application/FileService.java
@@ -27,28 +27,28 @@ public class FileService {
 
     @Transactional
     public String uploadImage(MultipartFile file) throws IOException {
-        String requestTypeSimpleName = "letter" + "/";
+        String folderName = "letter" + "/";
         String imageName = file.getOriginalFilename();
-        String fileName = requestTypeSimpleName + file.getOriginalFilename();
+        String fileName = folderName + file.getOriginalFilename();
 
-        uploadResizedImage(bucket, fileName, file);
+        createResizeImage(bucket, fileName, file);
 
-        return bucketUrl + requestTypeSimpleName + imageName;
+        return bucketUrl + folderName + imageName;
     }
 
-    private void uploadResizedImage(String bucketName, String fileName, MultipartFile image) throws IOException {
+    private void createResizeImage(String bucketName, String fileName, MultipartFile image) throws IOException {
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentType(image.getContentType());
         metadata.setContentLength(image.getSize());
 
-        byte[] buffer = getResizedImageStream(image);
+        byte[] buffer = resizeImage(image);
         metadata.setContentLength(buffer.length);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(buffer);
 
         amazonS3Client.putObject(bucketName, fileName, inputStream, metadata);
     }
 
-    private byte[] getResizedImageStream(MultipartFile image) throws IOException {
+    private byte[] resizeImage(MultipartFile image) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         Thumbnails.of(image.getInputStream()).size(400, 400).toOutputStream(outputStream);
         return outputStream.toByteArray();

--- a/src/main/java/dnd/myOcean/domain/letterimage/domain/LetterImage.java
+++ b/src/main/java/dnd/myOcean/domain/letterimage/domain/LetterImage.java
@@ -3,16 +3,13 @@ package dnd.myOcean.domain.letterimage.domain;
 
 import dnd.myOcean.domain.letterimage.exception.NoExtException;
 import dnd.myOcean.domain.letterimage.exception.UnSupportExtException;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import java.util.Arrays;
-import java.util.UUID;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.Arrays;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -26,15 +23,19 @@ public class LetterImage {
     @Column(name = "letter_image_id")
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, updatable = false)
     private String uniqueName;
 
-    @Column(nullable = false)
+    @Column(nullable = false, updatable = false)
     private String originName;
 
-    public LetterImage(String originName) {
+    @Column(nullable = false, updatable = false)
+    private String imagePath;
+
+    public LetterImage(String imagePath, String originName) {
         this.originName = originName;
         this.uniqueName = extractExtAndGenerateUniqueName(originName);
+        this.imagePath = imagePath;
     }
 
     private String extractExtAndGenerateUniqueName(String originName) {

--- a/src/main/java/dnd/myOcean/global/config/S3Config.java
+++ b/src/main/java/dnd/myOcean/global/config/S3Config.java
@@ -1,0 +1,29 @@
+package dnd.myOcean.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,6 +65,13 @@ jwt:
   access-token-validity-in-seconds: 86400 # (배포 시 30분 -> 1800 설정)
   refresh-token-validity-in-seconds: 86400 # (배포 시 1일 -> 86400설정)
 
-upload:
-  image:
-    location: ${local.image.location}
+cloud:
+  aws:
+    s3:
+      bucket: '${cloud.aws.s3.bucket}'
+      url: '${cloud.aws.s3.url}'
+    stack.auto: false
+    region.static: ap-northeast-2
+    credentials:
+      accessKey: '${cloud.aws.s3.credentials.accessKey}'
+      secretKey: '${cloud.aws.s3.credentials.secretKey}'


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 자동으로 닫을 이슈 번호를 작성해주세요 ex) #11 -->
- close #54 

## ✅ 작업 사항
- S3 버킷을 이용한 이미지 등록 기능 (테스트 완료)
- 성능을 위한 이미지 리사이징 기능

## 👩‍💻 공유 포인트 및 논의 사항

원본 사진
![원본 사진](https://github.com/dnd-side-project/dnd-10th-4-backend/assets/95893341/e3cdd3e1-956d-40d7-af6c-58c90c9e369e)

리사이징 후 크기가 작아진 것을 볼 수 있습니다.
![리사이징](https://github.com/dnd-side-project/dnd-10th-4-backend/assets/95893341/846b96d1-96e5-4657-97bb-b0563c402bab)

- 추가

1. 이미지 등록을 위해 throw 키워드가 연관된 메소드에 계속 붙게 되는데, 알아보니 `@SneakyThrows (IOException.class)` 을 메소드 위에 붙이게 되는데, 이 부분도 연관된 메소드에 계속 붙여야 되는것같음 

2. 이미지가 저장된 S3 버킷 URL 경로를 `LetterImage` 엔티티 클래스에 컬럼을 추가함 (읽기 전용 컬럼으로 만듬)

3. 리사이징한 이미지 크기를 가로 400 세로 400으로 하였는데, 이 부분은 환경변수로 뺄 수도 있을 것 같음
