### PR TITLE
Feature/#73 관리자 API 구현

### DIFF
--- a/src/main/java/dnd/myOcean/MyOceanApplication.java
+++ b/src/main/java/dnd/myOcean/MyOceanApplication.java
@@ -7,7 +7,9 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
+@EnableMethodSecurity
 @EnableAspectJAutoProxy
 @EnableJpaAuditing
 @EnableAsync

--- a/src/main/java/dnd/myOcean/letter/api/LetterController.java
+++ b/src/main/java/dnd/myOcean/letter/api/LetterController.java
@@ -5,6 +5,7 @@ import dnd.myOcean.global.auth.aop.dto.CurrentMemberIdRequest;
 import dnd.myOcean.letter.application.LetterService;
 import dnd.myOcean.letter.domain.dto.request.LetterReplyRequest;
 import dnd.myOcean.letter.domain.dto.request.LetterSendRequest;
+import dnd.myOcean.letter.domain.dto.request.SpecialLetterSendRequest;
 import dnd.myOcean.letter.domain.dto.response.ReceivedLetterResponse;
 import dnd.myOcean.letter.domain.dto.response.RepliedLetterResponse;
 import dnd.myOcean.letter.domain.dto.response.SendLetterResponse;
@@ -32,9 +33,16 @@ public class LetterController {
 
     private final LetterService letterService;
 
+    @PostMapping("/special")
+    @AssignCurrentMemberId
+    public ResponseEntity<Void> sendSpecialLetter(@ModelAttribute SpecialLetterSendRequest request) throws IOException {
+        letterService.sendByEmail(request);
+        return new ResponseEntity(HttpStatus.CREATED);
+    }
+
     @PostMapping
     @AssignCurrentMemberId
-    public ResponseEntity<Void> send(@ModelAttribute LetterSendRequest request) throws IOException {
+    public ResponseEntity<Void> sendLetter(@ModelAttribute LetterSendRequest request) throws IOException {
         letterService.send(request);
         return new ResponseEntity(HttpStatus.CREATED);
     }

--- a/src/main/java/dnd/myOcean/letter/api/LetterController.java
+++ b/src/main/java/dnd/myOcean/letter/api/LetterController.java
@@ -18,6 +18,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -34,6 +35,7 @@ public class LetterController {
     private final LetterService letterService;
 
     @PostMapping("/special")
+    @PreAuthorize("hasAuthority('ADMIN')")
     @AssignCurrentMemberId
     public ResponseEntity<Void> sendSpecialLetter(@ModelAttribute SpecialLetterSendRequest request) throws IOException {
         letterService.sendByEmail(request);
@@ -41,6 +43,7 @@ public class LetterController {
     }
 
     @PostMapping
+    @PreAuthorize("hasAuthority('ADMIN')")
     @AssignCurrentMemberId
     public ResponseEntity<Void> sendLetter(@ModelAttribute LetterSendRequest request) throws IOException {
         letterService.send(request);

--- a/src/main/java/dnd/myOcean/letter/domain/Letter.java
+++ b/src/main/java/dnd/myOcean/letter/domain/Letter.java
@@ -83,6 +83,7 @@ public class Letter extends BaseEntity {
                                       final LetterTag letterTag, final LetterImage sendletterImage, final String uuid) {
         return Letter.builder()
                 .sender(sender)
+                .letterType("Normal")
                 .content(content)
                 .receiver(receiver)
                 .worryType(worryType)
@@ -102,7 +103,21 @@ public class Letter extends BaseEntity {
                 .sender(sender)
                 .letterType("Onboarding")
                 .content(content)
-                .replyContent("온보딩 편지에 대한 답장")
+                .receiver(receiver)
+                .sendletterImage(sendletterImage)
+                .isDeleteBySender(false)
+                .hasReplied(false)
+                .isStored(false)
+                .build();
+    }
+
+    public static Letter createSpecialLetter(final Member sender, final Member receiver,
+                                             final LetterImage sendletterImage,
+                                             final String content) {
+        return Letter.builder()
+                .sender(sender)
+                .letterType("Special")
+                .content(content)
                 .receiver(receiver)
                 .sendletterImage(sendletterImage)
                 .isDeleteBySender(false)
@@ -128,5 +143,9 @@ public class Letter extends BaseEntity {
 
     public void updateReceiver(final Member receiver) {
         this.receiver = receiver;
+    }
+
+    public boolean isNormalLetter() {
+        return this.letterType.equals("Normal");
     }
 }

--- a/src/main/java/dnd/myOcean/letter/domain/dto/request/SpecialLetterSendRequest.java
+++ b/src/main/java/dnd/myOcean/letter/domain/dto/request/SpecialLetterSendRequest.java
@@ -1,0 +1,28 @@
+package dnd.myOcean.letter.domain.dto.request;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Null;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SpecialLetterSendRequest {
+
+    @Null
+    private Long memberId;
+
+    @NotEmpty(message = "받을 사람의 이메일을 입력해주세요.")
+    private String email;
+
+    @NotEmpty(message = "편지 내용을 입력해주세요.")
+    private String content;
+
+    @Nullable
+    private MultipartFile image;
+}

--- a/src/main/java/dnd/myOcean/letter/exception/PassDeniedLetterException.java
+++ b/src/main/java/dnd/myOcean/letter/exception/PassDeniedLetterException.java
@@ -1,0 +1,4 @@
+package dnd.myOcean.letter.exception;
+
+public class PassDeniedLetterException extends RuntimeException {
+}

--- a/src/main/java/dnd/myOcean/member/api/MemberController.java
+++ b/src/main/java/dnd/myOcean/member/api/MemberController.java
@@ -18,10 +18,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -36,8 +36,8 @@ public class MemberController {
         return new ResponseEntity<>(memberService.findAllMember(cond), HttpStatus.OK);
     }
 
-    @DeleteMapping("/{email}")
-    public ResponseEntity<Void> deleteByEmail(@PathVariable("email") String email) {
+    @DeleteMapping
+    public ResponseEntity<Void> deleteByEmail(@RequestParam("email") String email) {
         memberService.deleteByEmail(email);
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/dnd/myOcean/member/api/MemberController.java
+++ b/src/main/java/dnd/myOcean/member/api/MemberController.java
@@ -15,6 +15,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -36,6 +37,7 @@ public class MemberController {
         return new ResponseEntity<>(memberService.findAllMember(cond), HttpStatus.OK);
     }
 
+    @PreAuthorize("hasAuthority('ADMIN')")
     @DeleteMapping
     public ResponseEntity<Void> deleteByEmail(@RequestParam("email") String email) {
         memberService.deleteByEmail(email);

--- a/src/main/java/dnd/myOcean/member/api/MemberController.java
+++ b/src/main/java/dnd/myOcean/member/api/MemberController.java
@@ -8,13 +8,17 @@ import dnd.myOcean.member.domain.dto.request.GenderUpdateRequest;
 import dnd.myOcean.member.domain.dto.request.InfoUpdateRequest;
 import dnd.myOcean.member.domain.dto.request.NicknameUpdateRequest;
 import dnd.myOcean.member.domain.dto.request.WorryCreateRequest;
-import dnd.myOcean.member.domain.dto.response.MemberInfoResponse;
+import dnd.myOcean.member.domain.dto.response.CurrentMemberInfoResponse;
+import dnd.myOcean.member.repository.infra.querydsl.dto.MemberReadCondition;
+import dnd.myOcean.member.repository.infra.querydsl.dto.PagedMemberResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,9 +31,20 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    @GetMapping("/search")
+    public ResponseEntity<PagedMemberResponse> getMembersInfo(@Valid MemberReadCondition cond) {
+        return new ResponseEntity<>(memberService.findAllMember(cond), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{email}")
+    public ResponseEntity<Void> deleteByEmail(@PathVariable("email") String email) {
+        memberService.deleteByEmail(email);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
     @GetMapping
     @AssignCurrentMemberId
-    public ResponseEntity<MemberInfoResponse> getMyInfo(CurrentMemberIdRequest request) {
+    public ResponseEntity<CurrentMemberInfoResponse> getMyInfo(CurrentMemberIdRequest request) {
         return new ResponseEntity(memberService.getMyInfo(request), HttpStatus.OK);
     }
 

--- a/src/main/java/dnd/myOcean/member/domain/dto/response/CurrentMemberInfoResponse.java
+++ b/src/main/java/dnd/myOcean/member/domain/dto/response/CurrentMemberInfoResponse.java
@@ -1,7 +1,11 @@
 package dnd.myOcean.member.domain.dto.response;
 
+
 import dnd.myOcean.member.domain.Member;
+import dnd.myOcean.member.domain.WorryType;
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MemberInfoResponse {
+public class CurrentMemberInfoResponse {
 
     private Long id;
     private String role;
@@ -19,14 +23,22 @@ public class MemberInfoResponse {
     private String gender;
     private LocalDate birthDay;
     private Integer age;
+    private List<WorryType> worryTypes;
+    private Integer letterCount;
 
-    public static MemberInfoResponse of(final Member member) {
-        return new MemberInfoResponse(member.getId(),
+    public static CurrentMemberInfoResponse of(final Member member) {
+        List<WorryType> worryTypes = member.getWorries().stream()
+                .map(memberWorry -> memberWorry.getWorry().getWorryType())
+                .collect(Collectors.toList());
+
+        return new CurrentMemberInfoResponse(member.getId(),
                 member.getRole().name(),
                 member.getEmail(),
                 member.getNickName(),
                 member.getGender().name(),
                 member.getBirthDay(),
-                member.getAge());
+                member.getAge(),
+                worryTypes,
+                member.getLetterCount());
     }
 }

--- a/src/main/java/dnd/myOcean/member/repository/infra/jpa/MemberRepository.java
+++ b/src/main/java/dnd/myOcean/member/repository/infra/jpa/MemberRepository.java
@@ -3,13 +3,14 @@ package dnd.myOcean.member.repository.infra.jpa;
 import dnd.myOcean.member.domain.Gender;
 import dnd.myOcean.member.domain.Member;
 import dnd.myOcean.member.domain.WorryType;
+import dnd.myOcean.member.repository.infra.querydsl.MemberQuerydslRepository;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberQuerydslRepository {
 
     Optional<Member> findByEmail(String email);
 

--- a/src/main/java/dnd/myOcean/member/repository/infra/querydsl/MemberQuerydslRepository.java
+++ b/src/main/java/dnd/myOcean/member/repository/infra/querydsl/MemberQuerydslRepository.java
@@ -1,0 +1,10 @@
+package dnd.myOcean.member.repository.infra.querydsl;
+
+import dnd.myOcean.member.domain.dto.response.MemberInfoResponse;
+import dnd.myOcean.member.repository.infra.querydsl.dto.MemberReadCondition;
+import org.springframework.data.domain.Page;
+
+public interface MemberQuerydslRepository {
+
+    Page<MemberInfoResponse> findAllMember(MemberReadCondition cond);
+}

--- a/src/main/java/dnd/myOcean/member/repository/infra/querydsl/MemberQuerydslRepositoryImpl.java
+++ b/src/main/java/dnd/myOcean/member/repository/infra/querydsl/MemberQuerydslRepositoryImpl.java
@@ -1,0 +1,71 @@
+package dnd.myOcean.member.repository.infra.querydsl;
+
+import static com.querydsl.core.types.Projections.constructor;
+import static dnd.myOcean.member.domain.QMember.member;
+import static dnd.myOcean.member.domain.QMemberWorry.memberWorry;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import dnd.myOcean.member.domain.Member;
+import dnd.myOcean.member.domain.dto.response.MemberInfoResponse;
+import dnd.myOcean.member.repository.infra.querydsl.dto.MemberReadCondition;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class MemberQuerydslRepositoryImpl extends QuerydslRepositorySupport implements MemberQuerydslRepository {
+
+    private final JPAQueryFactory query;
+
+    public MemberQuerydslRepositoryImpl(JPAQueryFactory query) {
+        super(Member.class);
+        this.query = query;
+    }
+
+    @Override
+    public Page<MemberInfoResponse> findAllMember(MemberReadCondition cond) {
+        Pageable pageable = PageRequest.of(cond.getPage(), cond.getSize());
+        Predicate predicate = createPredicate(cond);
+        return new PageImpl<>(fetchAllMember(predicate, pageable), pageable, fetchCount(predicate));
+    }
+
+    private Predicate createPredicate(MemberReadCondition cond) {
+        BooleanBuilder builder = new BooleanBuilder();
+        if (cond.getEmail() != null) {
+            builder.and(member.email.eq(cond.getEmail()));
+            return builder;
+        }
+        return builder;
+    }
+
+    private List<MemberInfoResponse> fetchAllMember(Predicate predicate, Pageable pageable) {
+        return getQuerydsl().applyPagination(
+                pageable,
+                query.select(constructor(MemberInfoResponse.class,
+                                member.id,
+                                member.role.stringValue(),
+                                member.email,
+                                member.nickName,
+                                member.gender.stringValue(),
+                                member.birthDay,
+                                member.age))
+                        .from(member)
+                        .leftJoin(member.worries, memberWorry)
+                        .where(predicate)
+                        .orderBy(member.createDate.asc())
+        ).fetch();
+    }
+
+    private Long fetchCount(Predicate predicate) {
+        return query.select(member.count())
+                .from(member)
+                .where(predicate)
+                .fetchOne();
+    }
+}

--- a/src/main/java/dnd/myOcean/member/repository/infra/querydsl/dto/MemberReadCondition.java
+++ b/src/main/java/dnd/myOcean/member/repository/infra/querydsl/dto/MemberReadCondition.java
@@ -1,0 +1,33 @@
+package dnd.myOcean.member.repository.infra.querydsl.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Data;
+
+@Data
+public class MemberReadCondition {
+
+    @NotNull(message = "페이지 번호를 입력해주세요.")
+    @PositiveOrZero(message = "올바른 페이지 번호를 입력해주세요. (0 이상)")
+    private Integer page;
+
+    @NotNull(message = "페이지 크기를 입력해주세요.")
+    @Positive(message = "올바른 페이지 크기를 입력해주세요. (1 이상)")
+    private Integer size;
+
+    private String email;
+
+    public MemberReadCondition() {
+        this.page = getDefaultPageNum();
+        this.size = getDefaultPageSize();
+    }
+
+    private int getDefaultPageNum() {
+        return 0;
+    }
+
+    private int getDefaultPageSize() {
+        return 10;
+    }
+}

--- a/src/main/java/dnd/myOcean/member/repository/infra/querydsl/dto/PagedMemberResponse.java
+++ b/src/main/java/dnd/myOcean/member/repository/infra/querydsl/dto/PagedMemberResponse.java
@@ -1,0 +1,27 @@
+package dnd.myOcean.member.repository.infra.querydsl.dto;
+
+import dnd.myOcean.member.domain.dto.response.MemberInfoResponse;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+@Data
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PagedMemberResponse {
+
+    private Long totalElements;
+    private Integer totalPage;
+    private boolean hasNextPage;
+    private List<MemberInfoResponse> letters;
+
+    public static PagedMemberResponse of(Page<MemberInfoResponse> page) {
+        return new PagedMemberResponse(page.getTotalElements(),
+                page.getTotalPages(),
+                page.hasNext(),
+                page.getContent());
+    }
+}

--- a/src/main/java/dnd/myOcean/member/repository/infra/querydsl/dto/PagedMemberResponse.java
+++ b/src/main/java/dnd/myOcean/member/repository/infra/querydsl/dto/PagedMemberResponse.java
@@ -16,7 +16,7 @@ public class PagedMemberResponse {
     private Long totalElements;
     private Integer totalPage;
     private boolean hasNextPage;
-    private List<MemberInfoResponse> letters;
+    private List<MemberInfoResponse> members;
 
     public static PagedMemberResponse of(Page<MemberInfoResponse> page) {
         return new PagedMemberResponse(page.getTotalElements(),

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -10,8 +10,7 @@ VALUES ('WORK'),
 
 INSERT INTO member(create_Date, update_age_count, update_gender_count, email, nick_name, gender, role, age, birth_day,
                    letter_count)
-VALUES (now(), 1, 1, 'oceanLetter1@gmail.com', '낯선 바다', 'MALE', 'USER', 26, '1999-04-22', 5),
-       (now(), 1, 1, 'kdo0422@nate.com', '낯선 바다', 'MALE', 'USER', 26, '1999-04-22', 5);
+VALUES (now(), 1, 1, 'oceanLetter1@gmail.com', '낯선 바다', 'MALE', 'USER', 26, '1999-04-22', 5);
 
 INSERT INTO letter_image(unique_name, origin_name, image_path)
 VALUES ('oceanImage.jpeg', 'oceanImage.jpeg',

--- a/src/test/java/dnd/myOcean/member/MemberServiceTest.java
+++ b/src/test/java/dnd/myOcean/member/MemberServiceTest.java
@@ -11,7 +11,7 @@ import dnd.myOcean.member.domain.Role;
 import dnd.myOcean.member.domain.Worry;
 import dnd.myOcean.member.domain.WorryType;
 import dnd.myOcean.member.domain.dto.request.InfoUpdateRequest;
-import dnd.myOcean.member.domain.dto.response.MemberInfoResponse;
+import dnd.myOcean.member.domain.dto.response.CurrentMemberInfoResponse;
 import dnd.myOcean.member.repository.infra.jpa.MemberRepository;
 import dnd.myOcean.member.repository.infra.jpa.WorryRepository;
 import java.time.LocalDate;
@@ -87,7 +87,7 @@ public class MemberServiceTest {
         given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
         CurrentMemberIdRequest request = new CurrentMemberIdRequest(1L);
 
-        MemberInfoResponse response = memberService.getMyInfo(request);
+        CurrentMemberInfoResponse response = memberService.getMyInfo(request);
 
         then(response).isNotNull();
         then(response.getId()).isEqualTo(member.getId());


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 자동으로 닫을 이슈 번호를 작성해주세요 ex) #11 -->
- close #73 


## ✅ 작업 사항

관리자 전용 API 구현
✅ 관리자가 보내는 편지 (이메일을 특정 사용자에게 보낼 수 있는 기능)

✅ 신고 회원 검색 조회 기능
검색 방법 1: 신고한사람 이메일 and 신고받은사람 이메일
검색 방법2 : 신고한사람 이메일
검색 방법3 : 신고받은사람 이메일

✅ 회원 조회 기능
- ✅ 전체조회
- ✅이메일 검색 조회

✅ 조회한 회원 탈퇴시키는 기능

✅ 관리자 API - 관리자만 접근 가능하도록 변경


## 👩‍💻 공유 포인트 및 논의 사항
✅ 관리자 카카오 계정 - 디스코드 채널에 공유

